### PR TITLE
perf: profile stellar resource budgets

### DIFF
--- a/stellar/Cargo.lock
+++ b/stellar/Cargo.lock
@@ -1667,6 +1667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wraith-stellar-bench"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "stealth-announcer",
+ "stealth-registry",
+ "stealth-sender",
+ "wraith-names",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/stellar/Cargo.toml
+++ b/stellar/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "stealth-registry",
   "stealth-sender",
   "wraith-names",
+  "bench",
 ]
 resolver = "2"
 

--- a/stellar/PERF.md
+++ b/stellar/PERF.md
@@ -1,0 +1,122 @@
+# Wraith Stellar Soroban Resource Budget Report
+
+Measured on 2026-06-01 with `soroban-sdk = 22.0.0` resolved to `22.0.11`.
+The reusable harness is in `stellar/bench/` and can be re-run with:
+
+```sh
+cargo run -p wraith-stellar-bench
+```
+
+## How to Read the Units
+
+Soroban metering separates execution and ledger access. `instructions` are modeled
+CPU instructions, `mem_bytes` are modeled memory bytes, `read_entries` and
+`write_entries` count ledger entries touched, `read_bytes` and `write_bytes` are
+the serialized ledger bytes read or written, and `event_bytes` is the serialized
+contract event payload. Fees are computed from these dimensions using network
+configuration, so an optimization can matter even when it only saves ledger bytes
+or event bytes. The SDK's `Env::cost_estimate().resources()` reports resources
+for the last top-level invocation in the test environment; production simulation
+with Soroban RPC should still be used before setting transaction fees.
+
+References:
+- https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/resource-and-fee-metering
+- https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Env.html
+
+## Baseline
+
+These baseline numbers were captured before the optimization below.
+
+| Contract | Function | Parameters | Instructions | Mem bytes | Read entries | Write entries | Read bytes | Write bytes | Event bytes |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| stealth-announcer | announce | metadata_len=0 | 15458 | 1666 | 1 | 0 | 104 | 0 | 216 |
+| stealth-announcer | announce | metadata_len=32 | 15458 | 1666 | 1 | 0 | 104 | 0 | 248 |
+| stealth-announcer | announce | metadata_len=256 | 15458 | 1666 | 1 | 0 | 104 | 0 | 472 |
+| stealth-announcer | announce | metadata_len=1024 | 15458 | 1666 | 1 | 0 | 104 | 0 | 1240 |
+| stealth-announcer | announce | metadata_len=4096 | 15458 | 1666 | 1 | 0 | 104 | 0 | 4312 |
+| stealth-registry | register_keys | first_time | 33345 | 4461 | 1 | 2 | 104 | 332 | 188 |
+| stealth-registry | register_keys | replacement | 44880 | 6553 | 1 | 2 | 260 | 332 | 188 |
+| stealth-sender | send | asset=xlm | 182403 | 28137 | 5 | 3 | 1068 | 520 | 484 |
+| stealth-sender | send | asset=issued | 182355 | 28137 | 5 | 3 | 1068 | 520 | 484 |
+| stealth-sender | batch_send | batch_size=1 | 184674 | 28137 | 5 | 3 | 1068 | 520 | 484 |
+| stealth-sender | batch_send | batch_size=5 | 807519 | 120229 | 5 | 7 | 1068 | 1416 | 2420 |
+| stealth-sender | batch_send | batch_size=10 | 1633634 | 245649 | 5 | 12 | 1068 | 2536 | 4840 |
+| stealth-sender | batch_send | batch_size=25 | 4322337 | 690609 | 5 | 27 | 1068 | 5896 | 12100 |
+| wraith-names | register | name_len=3 | 59800 | 6269 | 1 | 2 | 104 | 544 | 204 |
+| wraith-names | register | name_len=32 | 61413 | 6327 | 1 | 2 | 104 | 572 | 232 |
+| wraith-names | resolve | hit | 46120 | 5537 | 1 | 0 | 476 | 0 | 0 |
+| wraith-names | resolve | miss | 19766 | 1600 | 1 | 0 | 104 | 0 | 0 |
+| wraith-names | name_of | hit | 50728 | 5554 | 1 | 0 | 476 | 0 | 0 |
+| wraith-names | name_of | miss | 21581 | 1513 | 1 | 0 | 104 | 0 | 0 |
+
+## Optimization Landed
+
+`wraith-names::name_of()` previously stored `Reverse(meta_hash) -> name_hash`,
+then loaded `Name(name_hash)` to return the human-readable name. The reverse map
+now stores `Reverse(meta_hash) -> name`, removing the second lookup for reverse
+resolution. This does not change public semantics for new deployments: register,
+update, release, resolve, and name_of return the same values and enforce the same
+ownership checks.
+
+| Case | Instructions Before | Instructions After | Delta | Mem Before | Mem After | Delta | Read Bytes Before | Read Bytes After | Delta |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| wraith-names name_of hit | 50728 | 47042 | -3686 (-7.3%) | 5554 | 5383 | -171 (-3.1%) | 476 | 452 | -24 (-5.0%) |
+| wraith-names register len=3 | 59800 | 59792 | -8 | 6269 | 6240 | -29 | 104 | 104 | 0 |
+| wraith-names resolve hit | 46120 | 46096 | -24 | 5537 | 5456 | -81 | 476 | 452 | -24 |
+
+## Current Numbers
+
+These are the post-optimization harness results.
+
+| Contract | Function | Parameters | Instructions | Mem bytes | Read entries | Write entries | Read bytes | Write bytes | Event bytes |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| stealth-announcer | announce | metadata_len=0 | 15458 | 1666 | 1 | 0 | 104 | 0 | 216 |
+| stealth-announcer | announce | metadata_len=32 | 15458 | 1666 | 1 | 0 | 104 | 0 | 248 |
+| stealth-announcer | announce | metadata_len=256 | 15458 | 1666 | 1 | 0 | 104 | 0 | 472 |
+| stealth-announcer | announce | metadata_len=1024 | 15458 | 1666 | 1 | 0 | 104 | 0 | 1240 |
+| stealth-announcer | announce | metadata_len=4096 | 15458 | 1666 | 1 | 0 | 104 | 0 | 4312 |
+| stealth-registry | register_keys | first_time | 33345 | 4461 | 1 | 2 | 104 | 332 | 188 |
+| stealth-registry | register_keys | replacement | 44880 | 6553 | 1 | 2 | 260 | 332 | 188 |
+| stealth-sender | send | asset=xlm | 182403 | 28137 | 5 | 3 | 1068 | 520 | 484 |
+| stealth-sender | send | asset=issued | 182355 | 28137 | 5 | 3 | 1068 | 520 | 484 |
+| stealth-sender | batch_send | batch_size=1 | 184674 | 28137 | 5 | 3 | 1068 | 520 | 484 |
+| stealth-sender | batch_send | batch_size=5 | 807519 | 120229 | 5 | 7 | 1068 | 1416 | 2420 |
+| stealth-sender | batch_send | batch_size=10 | 1633634 | 245649 | 5 | 12 | 1068 | 2536 | 4840 |
+| stealth-sender | batch_send | batch_size=25 | 4322337 | 690609 | 5 | 27 | 1068 | 5896 | 12100 |
+| wraith-names | register | name_len=3 | 59792 | 6240 | 1 | 2 | 104 | 516 | 204 |
+| wraith-names | register | name_len=32 | 61413 | 6327 | 1 | 2 | 104 | 572 | 232 |
+| wraith-names | resolve | hit | 46096 | 5456 | 1 | 0 | 452 | 0 | 0 |
+| wraith-names | resolve | miss | 19766 | 1600 | 1 | 0 | 104 | 0 | 0 |
+| wraith-names | name_of | hit | 47042 | 5383 | 1 | 0 | 452 | 0 | 0 |
+| wraith-names | name_of | miss | 21581 | 1513 | 1 | 0 | 104 | 0 | 0 |
+
+## Top Optimization Opportunities
+
+1. Reduce per-recipient `batch_send` overhead. Batch size 25 costs 4,322,337
+   instructions and 690,609 memory bytes; the slope is dominated by repeated
+   token transfers and cross-contract announcement calls. Expected savings:
+   high for every multi-recipient payment.
+2. Cap or compress announcement metadata. CPU is flat for `announce`, but event
+   bytes scale directly from 216 bytes at empty metadata to 4,312 bytes at 4 KiB.
+   Expected savings: high for users who attach large metadata.
+3. Avoid the extra reverse lookup in `wraith-names::name_of`. Implemented in
+   this PR. Expected savings: medium for reverse lookup-heavy clients.
+4. Split name entry storage if resolve dominates. `resolve` loads the whole
+   `NameEntry`, including owner and name, to return only the meta-address.
+   Expected savings: medium, but it changes storage layout more broadly.
+5. Avoid duplicate metadata/key vector traversal in `batch_send`. Current code
+   validates lengths once and then does four indexed reads per recipient.
+   Expected savings: low to medium; correctness and readability should be
+   preserved.
+
+## Concrete Diff Suggestions
+
+1. Batch send: add a dedicated announcer batch API and invoke it once after all
+   transfers. This requires extending `stealth-announcer`, so it is a protocol
+   change and was not landed here.
+2. Metadata: enforce a product-level metadata size cap, or store only compact
+   view-tag payloads in the event. This is semantics-affecting for callers that
+   rely on arbitrary metadata and should be decided at the protocol layer.
+3. Reverse lookup: store the name string directly in `DataKey::Reverse`. This is
+   the optimization implemented here.
+

--- a/stellar/bench/Cargo.toml
+++ b/stellar/bench/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wraith-stellar-bench"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+stealth-announcer = { path = "../stealth-announcer" }
+stealth-registry = { path = "../stealth-registry" }
+stealth-sender = { path = "../stealth-sender" }
+wraith-names = { path = "../wraith-names" }

--- a/stellar/bench/src/main.rs
+++ b/stellar/bench/src/main.rs
@@ -1,0 +1,251 @@
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{vec, Address, Bytes, BytesN, Env, String as SorobanString, Vec as SorobanVec};
+
+use stealth_announcer::{StealthAnnouncerContract, StealthAnnouncerContractClient};
+use stealth_registry::{StealthRegistryContract, StealthRegistryContractClient};
+use stealth_sender::{StealthSenderContract, StealthSenderContractClient};
+use wraith_names::{WraithNamesContract, WraithNamesContractClient};
+
+#[derive(Clone)]
+struct Row {
+    contract: &'static str,
+    function: &'static str,
+    params: std::string::String,
+    instructions: i64,
+    mem_bytes: i64,
+    read_entries: u32,
+    write_entries: u32,
+    read_bytes: u32,
+    write_bytes: u32,
+    events_bytes: u32,
+}
+
+fn main() {
+    let mut rows = std::vec::Vec::new();
+
+    for metadata_len in [0u32, 32, 256, 1024, 4096] {
+        rows.push(measure(
+            "stealth-announcer",
+            "announce",
+            format!("metadata_len={metadata_len}"),
+            |env| {
+                let contract_id = env.register(StealthAnnouncerContract, ());
+                let client = StealthAnnouncerContractClient::new(env, &contract_id);
+                client.announce(
+                    &1,
+                    &Address::generate(env),
+                    &BytesN::from_array(env, &[7u8; 32]),
+                    &bytes(env, metadata_len, 9),
+                );
+            },
+        ));
+    }
+
+    rows.push(measure(
+        "stealth-registry",
+        "register_keys",
+        "first_time".into(),
+        |env| {
+            env.mock_all_auths();
+            let contract_id = env.register(StealthRegistryContract, ());
+            let client = StealthRegistryContractClient::new(env, &contract_id);
+            client.register_keys(&Address::generate(env), &1, &bytes(env, 64, 1));
+        },
+    ));
+
+    rows.push(measure(
+        "stealth-registry",
+        "register_keys",
+        "replacement".into(),
+        |env| {
+            env.mock_all_auths();
+            let contract_id = env.register(StealthRegistryContract, ());
+            let client = StealthRegistryContractClient::new(env, &contract_id);
+            let registrant = Address::generate(env);
+            client.register_keys(&registrant, &1, &bytes(env, 64, 1));
+            client.register_keys(&registrant, &1, &bytes(env, 64, 2));
+        },
+    ));
+
+    for asset in ["xlm", "issued"] {
+        rows.push(measure(
+            "stealth-sender",
+            "send",
+            format!("asset={asset}"),
+            |env| {
+                env.mock_all_auths();
+                let sender_contract_id = env.register(StealthSenderContract, ());
+                let announcer_id = env.register(StealthAnnouncerContract, ());
+                let client = StealthSenderContractClient::new(env, &sender_contract_id);
+                client.init(&announcer_id);
+                let (token, sender) = funded_token(env, asset == "xlm");
+                client.send(
+                    &sender,
+                    &token,
+                    &100,
+                    &1,
+                    &Address::generate(env),
+                    &BytesN::from_array(env, &[3u8; 32]),
+                    &bytes(env, 32, 4),
+                );
+            },
+        ));
+    }
+
+    for batch_size in [1u32, 5, 10, 25] {
+        rows.push(measure(
+            "stealth-sender",
+            "batch_send",
+            format!("batch_size={batch_size}"),
+            |env| {
+                env.mock_all_auths();
+                let sender_contract_id = env.register(StealthSenderContract, ());
+                let announcer_id = env.register(StealthAnnouncerContract, ());
+                let client = StealthSenderContractClient::new(env, &sender_contract_id);
+                client.init(&announcer_id);
+                let (token, sender) = funded_token(env, true);
+                let mut addresses: SorobanVec<Address> = vec![env];
+                let mut keys: SorobanVec<BytesN<32>> = vec![env];
+                let mut metadatas: SorobanVec<Bytes> = vec![env];
+                let mut amounts: SorobanVec<i128> = vec![env];
+                for i in 0..batch_size {
+                    addresses.push_back(Address::generate(env));
+                    keys.push_back(BytesN::from_array(env, &[i as u8; 32]));
+                    metadatas.push_back(bytes(env, 32, i as u8));
+                    amounts.push_back(100);
+                }
+                client.batch_send(&sender, &token, &1, &addresses, &keys, &metadatas, &amounts);
+            },
+        ));
+    }
+
+    for name_len in [3u32, 32] {
+        rows.push(measure(
+            "wraith-names",
+            "register",
+            format!("name_len={name_len}"),
+            |env| {
+                env.mock_all_auths();
+                let contract_id = env.register(WraithNamesContract, ());
+                let client = WraithNamesContractClient::new(env, &contract_id);
+                client.register(
+                    &Address::generate(env),
+                    &name(env, name_len),
+                    &bytes(env, 64, 5),
+                );
+            },
+        ));
+    }
+
+    rows.push(measure("wraith-names", "resolve", "hit".into(), |env| {
+        env.mock_all_auths();
+        let contract_id = env.register(WraithNamesContract, ());
+        let client = WraithNamesContractClient::new(env, &contract_id);
+        let n = SorobanString::from_str(env, "alice");
+        client.register(&Address::generate(env), &n, &bytes(env, 64, 6));
+        client.resolve(&n);
+    }));
+
+    rows.push(measure("wraith-names", "resolve", "miss".into(), |env| {
+        let contract_id = env.register(WraithNamesContract, ());
+        let client = WraithNamesContractClient::new(env, &contract_id);
+        let _ = client.try_resolve(&SorobanString::from_str(env, "missing"));
+    }));
+
+    rows.push(measure("wraith-names", "name_of", "hit".into(), |env| {
+        env.mock_all_auths();
+        let contract_id = env.register(WraithNamesContract, ());
+        let client = WraithNamesContractClient::new(env, &contract_id);
+        let meta = bytes(env, 64, 7);
+        client.register(
+            &Address::generate(env),
+            &SorobanString::from_str(env, "charlie"),
+            &meta,
+        );
+        client.name_of(&meta);
+    }));
+
+    rows.push(measure("wraith-names", "name_of", "miss".into(), |env| {
+        let contract_id = env.register(WraithNamesContract, ());
+        let client = WraithNamesContractClient::new(env, &contract_id);
+        let _ = client.try_name_of(&bytes(env, 64, 8));
+    }));
+
+    print_markdown(&rows);
+}
+
+fn measure<F>(
+    contract: &'static str,
+    function: &'static str,
+    params: std::string::String,
+    f: F,
+) -> Row
+where
+    F: FnOnce(&Env),
+{
+    let env = Env::default();
+    env.cost_estimate().budget().reset_unlimited();
+    f(&env);
+    let resources = env.cost_estimate().resources();
+    Row {
+        contract,
+        function,
+        params,
+        instructions: resources.instructions,
+        mem_bytes: resources.mem_bytes,
+        read_entries: resources.read_entries,
+        write_entries: resources.write_entries,
+        read_bytes: resources.read_bytes,
+        write_bytes: resources.write_bytes,
+        events_bytes: resources.contract_events_size_bytes,
+    }
+}
+
+fn funded_token(env: &Env, native: bool) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let sender = Address::generate(env);
+    let token = if native {
+        env.register_stellar_asset_contract_v2(admin.clone())
+            .address()
+    } else {
+        env.register_stellar_asset_contract_v2(Address::generate(env))
+            .address()
+    };
+    let asset = StellarAssetClient::new(env, &token);
+    asset.mint(&sender, &1_000_000);
+    (token, sender)
+}
+
+fn bytes(env: &Env, len: u32, fill: u8) -> Bytes {
+    let mut out = Bytes::new(env);
+    for _ in 0..len {
+        out.push_back(fill);
+    }
+    out
+}
+
+fn name(env: &Env, len: u32) -> SorobanString {
+    let raw = "abcdefghijklmnopqrstuvwxyz012345";
+    SorobanString::from_str(env, &raw[..len as usize])
+}
+
+fn print_markdown(rows: &[Row]) {
+    println!("| Contract | Function | Parameters | Instructions | Mem bytes | Read entries | Write entries | Read bytes | Write bytes | Event bytes |");
+    println!("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|");
+    for row in rows {
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+            row.contract,
+            row.function,
+            row.params,
+            row.instructions,
+            row.mem_bytes,
+            row.read_entries,
+            row.write_entries,
+            row.read_bytes,
+            row.write_bytes,
+            row.events_bytes,
+        );
+    }
+}

--- a/stellar/stealth-announcer/Cargo.toml
+++ b/stellar/stealth-announcer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/stellar/stealth-registry/Cargo.toml
+++ b/stellar/stealth-registry/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/stellar/stealth-sender/Cargo.toml
+++ b/stellar/stealth-sender/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/stellar/wraith-names/Cargo.toml
+++ b/stellar/wraith-names/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/stellar/wraith-names/src/lib.rs
+++ b/stellar/wraith-names/src/lib.rs
@@ -11,7 +11,7 @@ use soroban_sdk::{
 pub enum DataKey {
     /// Maps name hash (BytesN<32>) to NameEntry.
     Name(BytesN<32>),
-    /// Reverse lookup: meta-address hash (BytesN<32>) to name hash (BytesN<32>).
+    /// Reverse lookup: meta-address hash (BytesN<32>) to name string.
     Reverse(BytesN<32>),
 }
 
@@ -87,7 +87,7 @@ impl WraithNamesContract {
             BytesN::from_array(&env, &env.crypto().sha256(&stealth_meta_address).to_array());
         env.storage()
             .instance()
-            .set(&DataKey::Reverse(meta_hash), &name_hash);
+            .set(&DataKey::Reverse(meta_hash), &name);
 
         env.events().publish(
             (symbol_short!("register"), name_hash),
@@ -146,7 +146,7 @@ impl WraithNamesContract {
             BytesN::from_array(&env, &env.crypto().sha256(&new_meta_address).to_array());
         env.storage()
             .instance()
-            .set(&DataKey::Reverse(new_meta_hash), &name_hash);
+            .set(&DataKey::Reverse(new_meta_hash), &name);
 
         env.events().publish(
             (symbol_short!("register"), name_hash),
@@ -206,17 +206,12 @@ impl WraithNamesContract {
     pub fn name_of(env: Env, stealth_meta_address: Bytes) -> Result<String, NamesError> {
         let meta_hash =
             BytesN::from_array(&env, &env.crypto().sha256(&stealth_meta_address).to_array());
-        let name_hash: BytesN<32> = env
+        let name: String = env
             .storage()
             .instance()
             .get(&DataKey::Reverse(meta_hash))
             .ok_or(NamesError::NameNotFound)?;
-        let entry: NameEntry = env
-            .storage()
-            .instance()
-            .get(&DataKey::Name(name_hash))
-            .ok_or(NamesError::NameNotFound)?;
-        Ok(entry.name)
+        Ok(name)
     }
 
     /// Hash a name string to BytesN<32> for use as storage key.

--- a/stellar/wraith-names/test_snapshots/test/test_name_of_reverse.1.json
+++ b/stellar/wraith-names/test_snapshots/test/test_name_of_reverse.1.json
@@ -117,7 +117,7 @@
                           ]
                         },
                         "val": {
-                          "bytes": "b9dd960c1753459a78115d3cb845a57d924b6877e805b08bd01086ccdf34433c"
+                          "string": "charlie"
                         }
                       }
                     ]

--- a/stellar/wraith-names/test_snapshots/test/test_name_taken.1.json
+++ b/stellar/wraith-names/test_snapshots/test/test_name_taken.1.json
@@ -117,7 +117,7 @@
                           ]
                         },
                         "val": {
-                          "bytes": "81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9"
+                          "string": "bob"
                         }
                       }
                     ]

--- a/stellar/wraith-names/test_snapshots/test/test_register_and_resolve.1.json
+++ b/stellar/wraith-names/test_snapshots/test/test_register_and_resolve.1.json
@@ -117,7 +117,7 @@
                           ]
                         },
                         "val": {
-                          "bytes": "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"
+                          "string": "alice"
                         }
                       }
                     ]

--- a/stellar/wraith-names/test_snapshots/test/test_release.1.json
+++ b/stellar/wraith-names/test_snapshots/test/test_release.1.json
@@ -165,7 +165,7 @@
                           ]
                         },
                         "val": {
-                          "bytes": "61ea0803f8853523b777d414ace3130cd4d3f92de2cd7ff8695c337d79c2eeee"
+                          "string": "dave"
                         }
                       }
                     ]


### PR DESCRIPTION
Summary
Adds a reusable Stellar/Soroban resource budget profiling harness and documents baseline measurements for Wraith’s Stellar contracts. Also lands one safe optimization for wraith-names::name_of by storing the reverse lookup name directly instead of storing a name hash and performing a second lookup.

Changes

Added stellar/bench/ harness runnable with:
cargo run -p wraith-stellar-bench
Added stellar/PERF.md with:
Soroban resource unit explanation
Baseline budget table
Current post-optimization table
Top 5 optimization opportunities
Concrete diff suggestions for the top 3
Before/after numbers for the landed optimization
Updated Stellar contract crates to also emit rlib so the bench harness can reuse generated clients.
Optimized wraith-names::name_of reverse lookup:
Before: Reverse(meta_hash) -> name_hash, then load Name(name_hash)
After: Reverse(meta_hash) -> name
Optimization Result
wraith-names name_of hit improved:

Instructions: 50,728 -> 47,042  (-3,686 / -7.3%)
Memory bytes: 5,554 -> 5,383    (-171 / -3.1%)
Read bytes:   476 -> 452        (-24 / -5.0%)
Validation

cargo fmt --all -- --check
cargo test --workspace
cargo run -p wraith-stellar-bench
All passed.

Notes
The harness uses Env::cost_estimate().resources() in the Soroban test environment. These numbers are useful for relative optimization and regression checks, while production fee-setting should still use Soroban RPC simulation.


closes #6 