### PR TITLE
feat: multisig signer setup automation (#56)

### DIFF
--- a/stellar/MULTISIG.md
+++ b/stellar/MULTISIG.md
@@ -1,0 +1,159 @@
+# Stellar Multisig Setup
+
+Scripted, idempotent setup for the Wraith Protocol governance multisig on Stellar.  
+The `setup-multisig.sh` script configures signer weights and thresholds on a Stellar account in a single atomic transaction.
+
+## Recommended Starting Config (3-of-5)
+
+Per [GOVERNANCE.md](./GOVERNANCE.md), the admin account for `stealth-sender` and `wraith-names` should be a **3-of-5 Security Council multisig**.
+
+| Role | Named Guardian | Stellar Key |
+|---|---|---|
+| Guardian 1 | @truthixify | `G…` (populate before mainnet) |
+| Guardian 2 | @thebabalola | `G…` |
+| Guardian 3 | @bbkenny | `G…` |
+| Guardian 4 | @richiey1 | `G…` |
+| Guardian 5 | @drips-wave | `G…` |
+
+**Threshold**: 3 signatures required for all operations (low / med / high all set to 3).  
+**Master weight**: 0 (the base keypair is disabled; only the 5 named signers can act).
+
+### Initial Setup
+
+```bash
+cd stellar/scripts
+
+./setup-multisig.sh \
+  --network mainnet \
+  --account <ADMIN_ACCOUNT_G...> \
+  --signers "G_TRUTHIXIFY,G_THEBABALOLA,G_BBKENNY,G_RICHIEY1,G_DRIPS_WAVE" \
+  --threshold 3 \
+  --dry-run   # review first
+
+# If the plan looks correct, remove --dry-run to submit
+./setup-multisig.sh \
+  --network mainnet \
+  --account <ADMIN_ACCOUNT_G...> \
+  --signers "G_TRUTHIXIFY,G_THEBABALOLA,G_BBKENNY,G_RICHIEY1,G_DRIPS_WAVE" \
+  --threshold 3 \
+  --identity deployer
+```
+
+The script will verify the on-chain account state after submission and append a full audit log to `multisig-setup.log`.
+
+---
+
+## Recovery Procedure
+
+### Adding a Signer
+
+> Requires M-of-N current signers to co-sign (3 signatures for the 3-of-5 config).
+
+1. Collect the new signer's `G...` public key.
+2. Each co-signer builds and signs the `set_options` transaction:
+
+```bash
+stellar tx new set-options \
+  --network mainnet \
+  --source <ADMIN_ACCOUNT> \
+  --signer "<NEW_SIGNER_KEY>:1" \
+  --build-only \
+  --xdr-out add-signer.xdr
+
+# Each co-signer signs:
+stellar tx sign \
+  --network mainnet \
+  --sign-with-key <COSIGNER_IDENTITY> \
+  --xdr-in add-signer.xdr \
+  --xdr-out add-signer.xdr
+```
+
+3. Once 3 signatures are collected, submit:
+
+```bash
+stellar tx submit --network mainnet --xdr-in add-signer.xdr
+```
+
+4. After adding, if the new total signers changes the desired M-of-N ratio, also update thresholds (see below).
+
+### Removing a Signer
+
+1. Build the `set_options` transaction setting the departing signer's weight to 0:
+
+```bash
+stellar tx new set-options \
+  --network mainnet \
+  --source <ADMIN_ACCOUNT> \
+  --signer "<DEPARTING_KEY>:0" \
+  --build-only \
+  --xdr-out remove-signer.xdr
+```
+
+2. Collect M co-signatures (same process as above).
+3. Submit. **Important**: if removing a signer drops N below M, lower the threshold first in the same transaction, otherwise the account becomes permanently locked.
+
+### Updating Threshold Only
+
+```bash
+stellar tx new set-options \
+  --network mainnet \
+  --source <ADMIN_ACCOUNT> \
+  --low-threshold <NEW_T> \
+  --med-threshold <NEW_T> \
+  --high-threshold <NEW_T> \
+  --build-only \
+  --xdr-out update-threshold.xdr
+```
+
+Collect M signatures, then submit.
+
+### Emergency: Account Locked (threshold unreachable)
+
+If fewer than M signers are available and the account is locked:
+
+1. Contact remaining signers immediately — any M-of-N subset can still recover.
+2. If keys are lost and recovery is impossible, the account is permanently locked. This is a **non-recoverable** state for the admin account itself, but deployed contracts remain operational (they only call `require_auth` on their stored admin address; the contracts themselves are unaffected).
+3. To mitigate: keep an offline copy of all guardian keys in separate secure locations.
+
+---
+
+## Audit Trail
+
+Every run of `setup-multisig.sh` appends a timestamped log to `multisig-setup.log` (or `--log-file` path):
+
+```
+[2026-06-26T11:53:00Z] [INFO] === Multisig Setup Plan ===
+[2026-06-26T11:53:00Z] [INFO] Network:       futurenet
+[2026-06-26T11:53:00Z] [INFO] Account:       GABC...
+[2026-06-26T11:53:00Z] [INFO] Signers (N=5):
+[2026-06-26T11:53:00Z] [INFO]   GA1... (weight=1)
+...
+[2026-06-26T11:53:01Z] [INFO] Transaction built.
+[2026-06-26T11:53:02Z] [INFO] Submitting transaction...
+[2026-06-26T11:53:03Z] [INFO] ✓ High threshold confirmed: 3
+[2026-06-26T11:53:03Z] [INFO] Signers found on-chain: 5 (expected 5)
+[2026-06-26T11:53:03Z] [INFO] === Setup complete. Audit log: multisig-setup.log ===
+```
+
+Commit `multisig-setup.log` to your ops runbook repo (not this repository) after each governance change.
+
+---
+
+## Script Reference
+
+```
+./setup-multisig.sh [OPTIONS]
+
+Required:
+  --network    <testnet|futurenet|mainnet>
+  --account    <G... account to configure>
+  --signers    <comma-separated G... signer addresses>
+  --threshold  <integer M, must be ≤ number of signers>
+
+Optional:
+  --dry-run    Print plan without submitting any transaction
+  --identity   <stellar identity name>  (default: $STELLAR_IDENTITY or "default")
+  --log-file   <path>                   (default: multisig-setup.log)
+```
+
+Exit codes: `0` = success / dry-run OK, `1` = validation error or submission failure.

--- a/stellar/package.json
+++ b/stellar/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "verify:stellar-deployment": "node build/verify.js",
-    "recover": "tsx scripts/recover-storage.ts"
+    "recover": "tsx scripts/recover-storage.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^13.0.0",
@@ -15,6 +16,7 @@
     "@types/node": "^20.12.7",
     "ts-node": "^10.9.2",
     "tsx": "^4.22.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.9"
   }
 }

--- a/stellar/scripts/setup-multisig.sh
+++ b/stellar/scripts/setup-multisig.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# stellar/scripts/setup-multisig.sh
+#
+# Idempotent Stellar multisig signer setup.
+#
+# Usage:
+#   ./setup-multisig.sh [OPTIONS]
+#
+# Required options:
+#   --network     <testnet|futurenet|mainnet>
+#   --account     <G... source account to configure>
+#   --signers     <comma-separated G... signer addresses>
+#   --threshold   <M-of-N integer threshold>
+#
+# Optional flags:
+#   --dry-run     Print resulting account config without submitting
+#   --identity    <stellar identity name for signing; default: $STELLAR_IDENTITY or "default">
+#   --log-file    <path to append audit log; default: multisig-setup.log>
+#
+# Examples:
+#   # 3-of-5 dry-run on futurenet
+#   ./setup-multisig.sh \
+#     --network futurenet \
+#     --account GABC... \
+#     --signers "GA1...,GA2...,GA3...,GA4...,GA5..." \
+#     --threshold 3 \
+#     --dry-run
+#
+#   # Live setup
+#   ./setup-multisig.sh \
+#     --network futurenet \
+#     --account GABC... \
+#     --signers "GA1...,GA2...,GA3...,GA4...,GA5..." \
+#     --threshold 3 \
+#     --identity deployer
+
+set -euo pipefail
+
+# ---------- defaults --------------------------------------------------------
+NETWORK=""
+ACCOUNT=""
+SIGNERS_RAW=""
+THRESHOLD=""
+DRY_RUN=0
+IDENTITY="${STELLAR_IDENTITY:-default}"
+LOG_FILE="multisig-setup.log"
+
+# ---------- helpers ---------------------------------------------------------
+log() {
+  local level="$1"; shift
+  local msg="[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] [$level] $*"
+  echo "$msg"
+  echo "$msg" >> "$LOG_FILE"
+}
+
+die() {
+  local msg="[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] [ERROR] $*"
+  echo "$msg" >&2
+  echo "$msg" >> "$LOG_FILE"
+  exit 1
+}
+
+# Validates that a string is a Stellar G... public key (56 chars, base32).
+is_valid_gaddress() {
+  local addr="$1"
+  [[ "$addr" =~ ^G[A-Z2-7]{55}$ ]]
+}
+
+# ---------- arg parsing -----------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --network)   NETWORK="$2";   shift 2 ;;
+    --account)   ACCOUNT="$2";   shift 2 ;;
+    --signers)   SIGNERS_RAW="$2"; shift 2 ;;
+    --threshold) THRESHOLD="$2"; shift 2 ;;
+    --dry-run)   DRY_RUN=1;      shift   ;;
+    --identity)  IDENTITY="$2";  shift 2 ;;
+    --log-file)  LOG_FILE="$2";  shift 2 ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+done
+
+# ---------- validate required args ------------------------------------------
+[[ -n "$NETWORK" ]]    || die "--network is required"
+[[ -n "$ACCOUNT" ]]    || die "--account is required"
+[[ -n "$SIGNERS_RAW" ]] || die "--signers is required"
+[[ -n "$THRESHOLD" ]]  || die "--threshold is required"
+
+declare -A PASSPHRASES=(
+  [testnet]="Test SDF Network ; September 2015"
+  [futurenet]="Test SDF Future Network ; October 2022"
+  [mainnet]="Public Global Stellar Network ; September 2015"
+)
+[[ -n "${PASSPHRASES[$NETWORK]+x}" ]] || die "Unknown network '$NETWORK'"
+
+# ---------- parse + validate signers ----------------------------------------
+IFS=',' read -ra SIGNERS <<< "$SIGNERS_RAW"
+declare -a VALID_SIGNERS=()
+
+for s in "${SIGNERS[@]}"; do
+  s="${s// /}"  # strip spaces
+  if is_valid_gaddress "$s"; then
+    VALID_SIGNERS+=("$s")
+  else
+    die "Invalid signer address: '$s' (must be a 56-char G... Stellar public key)"
+  fi
+done
+
+N="${#VALID_SIGNERS[@]}"
+[[ "$N" -gt 0 ]] || die "At least one signer is required"
+
+if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [[ "$THRESHOLD" -lt 1 ]]; then
+  die "--threshold must be a positive integer"
+fi
+
+if [[ "$THRESHOLD" -gt "$N" ]]; then
+  die "Threshold ($THRESHOLD) cannot exceed number of signers ($N)"
+fi
+
+# Validate the target account address
+is_valid_gaddress "$ACCOUNT" || die "Invalid --account address: '$ACCOUNT'"
+
+# ---------- compute signer weight -------------------------------------------
+# Each signer gets weight 1. Master weight set to 0 (disabled).
+# low/med/high thresholds all set to THRESHOLD for uniform policy.
+WEIGHT_PER_SIGNER=1
+MASTER_WEIGHT=0
+
+# ---------- print plan -------------------------------------------------------
+log "INFO" "=== Multisig Setup Plan ==="
+log "INFO" "Network:       $NETWORK"
+log "INFO" "Account:       $ACCOUNT"
+log "INFO" "Signers (N=$N):"
+for s in "${VALID_SIGNERS[@]}"; do
+  log "INFO" "  $s (weight=$WEIGHT_PER_SIGNER)"
+done
+log "INFO" "Threshold:     $THRESHOLD-of-$N"
+log "INFO" "Master weight: $MASTER_WEIGHT (disabled)"
+log "INFO" "Low threshold: $THRESHOLD"
+log "INFO" "Med threshold: $THRESHOLD"
+log "INFO" "High threshold: $THRESHOLD"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  log "INFO" "[DRY-RUN] No transactions submitted."
+  exit 0
+fi
+
+# ---------- check stellar CLI available -------------------------------------
+command -v stellar >/dev/null 2>&1 || die "'stellar' CLI not found in PATH"
+
+# ---------- build set_options transaction -----------------------------------
+# Stellar CLI: set_options per signer, then master weight + thresholds.
+# We compose a single XDR envelope with all operations for atomicity.
+
+log "INFO" "Building set_options transaction..."
+
+# Temp file for XDR ops
+TMPXDR=$(mktemp /tmp/multisig-setup.XXXXXX.xdr)
+trap 'rm -f "$TMPXDR"' EXIT
+
+# Build signer add operations (one per signer)
+SIGNER_ARGS=()
+for s in "${VALID_SIGNERS[@]}"; do
+  SIGNER_ARGS+=(--signer "${s}:${WEIGHT_PER_SIGNER}")
+done
+
+stellar tx new set-options \
+  --network "$NETWORK" \
+  --source "$ACCOUNT" \
+  --build-only \
+  --master-weight "$MASTER_WEIGHT" \
+  --low-threshold "$THRESHOLD" \
+  --med-threshold "$THRESHOLD" \
+  --high-threshold "$THRESHOLD" \
+  "${SIGNER_ARGS[@]}" \
+  --xdr-out "$TMPXDR" \
+  2>&1 | while IFS= read -r line; do log "STELLAR" "$line"; done
+
+log "INFO" "Transaction built. Signing with identity '$IDENTITY'..."
+
+stellar tx sign \
+  --network "$NETWORK" \
+  --sign-with-key "$IDENTITY" \
+  --xdr-in "$TMPXDR" \
+  --xdr-out "$TMPXDR" \
+  2>&1 | while IFS= read -r line; do log "STELLAR" "$line"; done
+
+log "INFO" "Submitting transaction..."
+
+stellar tx submit \
+  --network "$NETWORK" \
+  --xdr-in "$TMPXDR" \
+  2>&1 | while IFS= read -r line; do log "STELLAR" "$line"; done
+
+# ---------- verification step -----------------------------------------------
+log "INFO" "Verifying account configuration..."
+
+ACCOUNT_JSON=$(stellar account show \
+  --network "$NETWORK" \
+  --account "$ACCOUNT" \
+  --json 2>/dev/null) || die "Failed to read back account state"
+
+# Check master weight is 0
+ACTUAL_MASTER=$(echo "$ACCOUNT_JSON" | grep -o '"master_weight":[^,}]*' | grep -o '[0-9]*' || echo "")
+if [[ "$ACTUAL_MASTER" == "$MASTER_WEIGHT" ]]; then
+  log "INFO" "✓ Master weight confirmed: $ACTUAL_MASTER"
+else
+  log "WARN" "Master weight mismatch: expected $MASTER_WEIGHT, got $ACTUAL_MASTER"
+fi
+
+# Check threshold
+ACTUAL_HIGH=$(echo "$ACCOUNT_JSON" | grep -o '"high_threshold":[^,}]*' | grep -o '[0-9]*' || echo "")
+if [[ "$ACTUAL_HIGH" == "$THRESHOLD" ]]; then
+  log "INFO" "✓ High threshold confirmed: $ACTUAL_HIGH"
+else
+  log "WARN" "High threshold mismatch: expected $THRESHOLD, got $ACTUAL_HIGH"
+fi
+
+# Count signers
+SIGNER_COUNT=$(echo "$ACCOUNT_JSON" | grep -o '"key":"G[A-Z2-7]*"' | wc -l || echo "0")
+log "INFO" "Signers found on-chain: $SIGNER_COUNT (expected $N)"
+
+log "INFO" "=== Setup complete. Audit log: $LOG_FILE ==="

--- a/stellar/scripts/setup-multisig.test.ts
+++ b/stellar/scripts/setup-multisig.test.ts
@@ -1,0 +1,207 @@
+/**
+ * setup-multisig.test.ts
+ *
+ * Unit tests for the multisig setup script logic.
+ *
+ * For futurenet integration tests, set FUTURENET_ACCOUNT and FUTURENET_IDENTITY
+ * env vars before running, or they will be skipped.
+ *
+ * Run: npx vitest run scripts/setup-multisig.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import * as path from 'path';
+
+const SCRIPT = path.resolve(__dirname, 'setup-multisig.sh');
+
+// Valid G-address fixtures (56-char, base32 alphabet A-Z2-7)
+const VALID_SIGNERS = [
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+  'GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD',
+  'GEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE',
+  'GFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',
+];
+const VALID_ACCOUNT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+function runScript(args: string): { stdout: string; stderr: string; code: number } {
+  try {
+    const stdout = execSync(`bash "${SCRIPT}" ${args}`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', code: 0 };
+  } catch (e: any) {
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: e.status ?? 1 };
+  }
+}
+
+describe('setup-multisig.sh argument validation', () => {
+  it('exits non-zero with no arguments', () => {
+    const r = runScript('');
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/--network is required/);
+  });
+
+  it('exits non-zero when --account is missing', () => {
+    const r = runScript(`--network futurenet --signers "${VALID_SIGNERS[0]}" --threshold 1`);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/--account is required/);
+  });
+
+  it('exits non-zero when --signers is missing', () => {
+    const r = runScript(`--network futurenet --account ${VALID_ACCOUNT} --threshold 1`);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/--signers is required/);
+  });
+
+  it('exits non-zero when --threshold is missing', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${VALID_SIGNERS[0]}"`,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/--threshold is required/);
+  });
+
+  it('rejects unknown network', () => {
+    const r = runScript(
+      `--network devnet --account ${VALID_ACCOUNT} --signers "${VALID_SIGNERS[0]}" --threshold 1`,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/Unknown network/);
+  });
+
+  it('rejects invalid signer address', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "INVALID" --threshold 1 --dry-run`,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/Invalid signer address/);
+  });
+
+  it('rejects invalid account address', () => {
+    const r = runScript(
+      `--network futurenet --account NOTVALID --signers "${VALID_SIGNERS[0]}" --threshold 1 --dry-run`,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/Invalid --account address/);
+  });
+
+  it('rejects threshold greater than number of signers', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${VALID_SIGNERS[0]},${VALID_SIGNERS[1]}" --threshold 5 --dry-run`,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/Threshold.*cannot exceed/);
+  });
+
+  it('rejects threshold of 0', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${VALID_SIGNERS[0]}" --threshold 0 --dry-run`,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/must be a positive integer/);
+  });
+
+  it('rejects non-integer threshold', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${VALID_SIGNERS[0]}" --threshold 1.5 --dry-run`,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/must be a positive integer/);
+  });
+});
+
+describe('setup-multisig.sh dry-run output', () => {
+  const signerList = VALID_SIGNERS.slice(0, 5).join(',');
+
+  it('exits 0 in dry-run mode', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${signerList}" --threshold 3 --dry-run`,
+    );
+    expect(r.code).toBe(0);
+  });
+
+  it('prints plan with correct threshold', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${signerList}" --threshold 3 --dry-run`,
+    );
+    expect(r.stdout).toMatch(/Threshold:\s+3-of-5/);
+  });
+
+  it('lists all signers in plan output', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${signerList}" --threshold 3 --dry-run`,
+    );
+    for (const s of VALID_SIGNERS.slice(0, 5)) {
+      expect(r.stdout).toContain(s);
+    }
+  });
+
+  it('shows master weight 0 in plan', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${signerList}" --threshold 3 --dry-run`,
+    );
+    expect(r.stdout).toMatch(/Master weight:\s+0/);
+  });
+
+  it('shows DRY-RUN notice and no submission', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${signerList}" --threshold 3 --dry-run`,
+    );
+    expect(r.stdout).toMatch(/DRY-RUN.*No transactions submitted/);
+  });
+
+  it('handles single signer threshold 1-of-1', () => {
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${VALID_SIGNERS[0]}" --threshold 1 --dry-run`,
+    );
+    expect(r.code).toBe(0);
+    expect(r.stdout).toMatch(/Threshold:\s+1-of-1/);
+  });
+
+  it('accepts all three supported networks', () => {
+    for (const net of ['testnet', 'futurenet', 'mainnet']) {
+      const r = runScript(
+        `--network ${net} --account ${VALID_ACCOUNT} --signers "${signerList}" --threshold 3 --dry-run`,
+      );
+      expect(r.code).toBe(0);
+    }
+  });
+
+  it('strips whitespace from signer addresses', () => {
+    const spacedSigners = VALID_SIGNERS.slice(0, 2).join(', ');
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${spacedSigners}" --threshold 1 --dry-run`,
+    );
+    expect(r.code).toBe(0);
+  });
+
+  it('writes to log file', () => {
+    const logFile = `/tmp/multisig-test-${Date.now()}.log`;
+    const r = runScript(
+      `--network futurenet --account ${VALID_ACCOUNT} --signers "${signerList}" --threshold 3 --dry-run --log-file "${logFile}"`,
+    );
+    expect(r.code).toBe(0);
+    const { readFileSync, existsSync } = require('fs');
+    expect(existsSync(logFile)).toBe(true);
+    const logContent = readFileSync(logFile, 'utf-8');
+    expect(logContent).toMatch(/Multisig Setup Plan/);
+    // cleanup
+    require('fs').unlinkSync(logFile);
+  });
+});
+
+describe('setup-multisig.sh futurenet integration', () => {
+  const FUTURENET_ACCOUNT = process.env['FUTURENET_ACCOUNT'];
+  const itIf = (cond: boolean) => (cond ? it : it.skip);
+
+  itIf(!!FUTURENET_ACCOUNT)('dry-run against real futurenet account address', () => {
+    const r = runScript(
+      `--network futurenet --account ${FUTURENET_ACCOUNT} --signers "${VALID_SIGNERS.slice(0, 3).join(',')}" --threshold 2 --dry-run`,
+    );
+    expect(r.code).toBe(0);
+    expect(r.stdout).toMatch(/Threshold:\s+2-of-3/);
+  });
+});


### PR DESCRIPTION
  - Add setup-multisig.sh: idempotent script for configuring signers + thresholds
  - Add setup-multisig.test.ts: 19 unit tests (dry-run + validation)
  - Add MULTISIG.md: recommended 3-of-5 config, recovery procedures, audit trail
  - Add vitest to stellar/package.json for test support
  - closes #56 