### PR TITLE
feat(stellar): on-chain multisig quorum rotation for signers (#104)

### DIFF
--- a/stellar/MULTISIG.md
+++ b/stellar/MULTISIG.md
@@ -139,6 +139,102 @@ Commit `multisig-setup.log` to your ops runbook repo (not this repository) after
 
 ---
 
+## On-Chain Signer Rotation (`stealth-sender`, `wraith-names`)
+
+The account-level Stellar multisig above governs the *admin key* that submits
+transactions. Separately, `stealth-sender` and `wraith-names` — the two
+contracts GOVERNANCE.md marks **Timelock + Multisig Upgradable** — each keep
+their own on-chain governance signer set and quorum threshold, used to
+authorise a `rotate_signers` flow without a contract redeploy (issue #104).
+
+This is intentionally a second, independent layer: the Stellar account
+multisig above controls *who can submit transactions at all*; the contract's
+own signer set controls *quorum + timelock for signer rotation specifically*,
+enforced by the contract itself regardless of which account submitted the
+call.
+
+### Flow
+
+1. **Propose** — any current signer proposes a new signer set + threshold.
+   Their approval is recorded automatically. Only one rotation may be
+   pending at a time.
+   ```bash
+   stellar contract invoke \
+     --network futurenet \
+     --id <CONTRACT_ID> \
+     --source <SIGNER_IDENTITY> \
+     -- propose_rotate_signers \
+     --caller <SIGNER_G...> \
+     --new_signers '["G_NEW1","G_NEW2","G_NEW3","G_NEW4","G_NEW5"]' \
+     --new_threshold 3
+   ```
+   Rejected with `InvalidThreshold` if `new_threshold` is `0` or greater than
+   `new_signers.len()` — a quorum that could never be reached.
+
+2. **Approve** — remaining current signers add their approval until quorum
+   (the *current* threshold) is met:
+   ```bash
+   stellar contract invoke \
+     --network futurenet \
+     --id <CONTRACT_ID> \
+     --source <SIGNER_IDENTITY> \
+     -- approve_rotate_signers \
+     --caller <SIGNER_G...>
+   ```
+
+3. **Wait out the timelock** — 7 days from the `propose` call
+   (`ROTATION_TIMELOCK_SECS`), mirroring the upgrade timelock in
+   GOVERNANCE.md.
+
+4. **Execute** — once quorum is met and the timelock has elapsed, any
+   current signer executes the rotation. This swaps in the new signer set
+   and threshold, clears the proposal, and emits `SignersRotated(new_signers,
+   old_threshold, new_threshold)`:
+   ```bash
+   stellar contract invoke \
+     --network futurenet \
+     --id <CONTRACT_ID> \
+     --source <SIGNER_IDENTITY> \
+     -- execute_rotate_signers \
+     --caller <SIGNER_G...>
+   ```
+   Fails with `QuorumNotMet` or `TimelockNotElapsed` if either condition
+   isn't satisfied yet.
+
+5. **Cancel (optional)** — any current signer can abort a pending rotation
+   before execution. This fully clears the proposal (including collected
+   approvals), so a fresh `propose_rotate_signers` can start immediately —
+   no leftover state blocks it:
+   ```bash
+   stellar contract invoke \
+     --network futurenet \
+     --id <CONTRACT_ID> \
+     --source <SIGNER_IDENTITY> \
+     -- cancel_rotate_signers \
+     --caller <SIGNER_G...>
+   ```
+
+### Inspecting state
+
+```bash
+stellar contract invoke --network futurenet --id <CONTRACT_ID> --source <ANY_IDENTITY> -- signers
+stellar contract invoke --network futurenet --id <CONTRACT_ID> --source <ANY_IDENTITY> -- threshold
+stellar contract invoke --network futurenet --id <CONTRACT_ID> --source <ANY_IDENTITY> -- pending_rotation
+```
+
+### Futurenet rehearsal
+
+> **Status: not yet rehearsed.** The flow above is covered by unit tests in
+> `stealth-sender/src/lib.rs` and `wraith-names/src/lib.rs` (quorum + timelock
+> enforcement, invalid-threshold rejection, and cancelled-mid-rotation state
+> cleanup), but has not been exercised against a live futurenet deployment.
+> Before relying on this runbook for a mainnet rotation, a maintainer with
+> futurenet deploy access should walk through propose → approve (x2) →
+> advance ledger time past the 7-day timelock → execute, and separately
+> propose → approve → cancel → propose again, confirming the CLI commands
+> above match the deployed contract interface, then update this section with
+> the confirmed transcript.
+
 ## Script Reference
 
 ```

--- a/stellar/stealth-sender/src/lib.rs
+++ b/stellar/stealth-sender/src/lib.rs
@@ -6,6 +6,9 @@ use soroban_sdk::{
 };
 use wraith_metrics::{contract_ids, dimension_names, emit_metric, metric_names};
 
+mod multisig;
+pub use multisig::RotationProposal;
+
 /// Storage keys.
 #[contracttype]
 #[derive(Clone)]
@@ -18,6 +21,12 @@ pub enum DataKey {
     FeeRecipient,
     /// Protocol fee in basis points (max 50 bps, 0 = disabled).
     FeeBasisPoints,
+    /// Governance multisig signer set.
+    MultisigSigners,
+    /// Governance multisig quorum threshold.
+    MultisigThreshold,
+    /// Pending signer-rotation proposal, if any.
+    PendingRotation,
 }
 
 /// Errors that the sender contract can produce.
@@ -35,6 +44,24 @@ pub enum SenderError {
     TokenNotAllowed = 4,
     /// The fee configuration is invalid (e.g. fee > 50 bps, or fee > 0 with no recipient).
     InvalidFeeConfig = 5,
+    /// The governance multisig has not been initialised.
+    MultisigNotInitialized = 6,
+    /// The governance multisig has already been initialised.
+    MultisigAlreadyInitialized = 7,
+    /// The caller is not a current governance signer.
+    NotSigner = 8,
+    /// The requested threshold is invalid (zero, or greater than signer count).
+    InvalidThreshold = 9,
+    /// A signer-rotation proposal is already pending.
+    RotationAlreadyPending = 10,
+    /// No signer-rotation proposal is pending.
+    NoPendingRotation = 11,
+    /// The caller has already approved the pending rotation.
+    AlreadyApprovedRotation = 12,
+    /// The pending rotation has not collected enough approvals yet.
+    QuorumNotMet = 13,
+    /// The rotation timelock has not elapsed yet.
+    TimelockNotElapsed = 14,
 }
 
 /// Lightweight client wrapper that invokes the StealthAnnouncer contract via
@@ -373,6 +400,59 @@ impl StealthSenderContract {
 
         Ok(())
     }
+
+    /// One-time setup of the governance signer set used to authorise signer
+    /// rotations. Independent of `init` — does not gate `send`/`batch_send`.
+    pub fn init_multisig(
+        env: Env,
+        signers: Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), SenderError> {
+        multisig::init(&env, signers, threshold)
+    }
+
+    /// Current governance signer set.
+    pub fn signers(env: Env) -> Vec<Address> {
+        multisig::signers(&env)
+    }
+
+    /// Current governance quorum threshold.
+    pub fn threshold(env: Env) -> u32 {
+        multisig::threshold(&env)
+    }
+
+    /// The pending signer-rotation proposal, if any.
+    pub fn pending_rotation(env: Env) -> Option<RotationProposal> {
+        multisig::pending_rotation(&env)
+    }
+
+    /// Propose a new signer set + threshold behind the rotation timelock.
+    /// `caller` must be a current signer; the proposal is auto-approved by
+    /// `caller`. Rejects thresholds that could never reach quorum.
+    pub fn propose_rotate_signers(
+        env: Env,
+        caller: Address,
+        new_signers: Vec<Address>,
+        new_threshold: u32,
+    ) -> Result<(), SenderError> {
+        multisig::propose_rotate_signers(&env, caller, new_signers, new_threshold)
+    }
+
+    /// Approve the pending signer-rotation proposal.
+    pub fn approve_rotate_signers(env: Env, caller: Address) -> Result<(), SenderError> {
+        multisig::approve_rotate_signers(&env, caller)
+    }
+
+    /// Execute the pending rotation once quorum is met and the timelock has
+    /// elapsed. Emits `SignersRotated`.
+    pub fn execute_rotate_signers(env: Env, caller: Address) -> Result<(), SenderError> {
+        multisig::execute_rotate_signers(&env, caller)
+    }
+
+    /// Cancel the pending rotation, clearing all of its state.
+    pub fn cancel_rotate_signers(env: Env, caller: Address) -> Result<(), SenderError> {
+        multisig::cancel_rotate_signers(&env, caller)
+    }
 }
 
 #[cfg(test)]
@@ -528,5 +608,148 @@ mod test {
         assert_eq!(token_client.balance(&sender), 500);
         assert_eq!(token_client.balance(&stealth_addr_1), 700);
         assert_eq!(token_client.balance(&stealth_addr_2), 800);
+    }
+
+    fn setup_multisig(env: &Env) -> (StealthSenderContractClient, Vec<Address>) {
+        let sender_id = env.register(StealthSenderContract, ());
+        let client = StealthSenderContractClient::new(env, &sender_id);
+
+        let signers = soroban_sdk::vec![
+            env,
+            Address::generate(env),
+            Address::generate(env),
+            Address::generate(env),
+            Address::generate(env),
+            Address::generate(env),
+        ];
+        client.init_multisig(&signers, &3);
+
+        (client, signers)
+    }
+
+    #[test]
+    fn test_init_multisig_rejects_invalid_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let sender_id = env.register(StealthSenderContract, ());
+        let client = StealthSenderContractClient::new(&env, &sender_id);
+
+        let signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+
+        // Zero threshold is unreachable.
+        let res = client.try_init_multisig(&signers, &0);
+        assert_eq!(res, Err(Ok(SenderError::InvalidThreshold)));
+
+        // Threshold greater than signer count is unreachable.
+        let res = client.try_init_multisig(&signers, &3);
+        assert_eq!(res, Err(Ok(SenderError::InvalidThreshold)));
+    }
+
+    #[test]
+    fn test_propose_rotate_signers_rejects_invalid_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+
+        let res = client.try_propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &0);
+        assert_eq!(res, Err(Ok(SenderError::InvalidThreshold)));
+
+        let res = client.try_propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &3);
+        assert_eq!(res, Err(Ok(SenderError::InvalidThreshold)));
+
+        // No proposal was recorded by the rejected attempts.
+        assert!(client.pending_rotation().is_none());
+    }
+
+    #[test]
+    fn test_rotate_signers_requires_quorum_and_timelock() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &2);
+
+        // Only one rotation may be pending at a time.
+        let res = client.try_propose_rotate_signers(&signers.get(1).unwrap(), &new_signers, &2);
+        assert_eq!(res, Err(Ok(SenderError::RotationAlreadyPending)));
+
+        // Only 1 of 3 required approvals so far (the proposer's).
+        let res = client.try_execute_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(SenderError::QuorumNotMet)));
+
+        client.approve_rotate_signers(&signers.get(1).unwrap());
+        client.approve_rotate_signers(&signers.get(2).unwrap());
+
+        // Quorum met, but the timelock has not elapsed yet.
+        let res = client.try_execute_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(SenderError::TimelockNotElapsed)));
+
+        env.ledger().with_mut(|li| {
+            li.timestamp += multisig::ROTATION_TIMELOCK_SECS;
+        });
+
+        client.execute_rotate_signers(&signers.get(0).unwrap());
+
+        assert_eq!(client.signers(), new_signers);
+        assert_eq!(client.threshold(), 2);
+        assert!(client.pending_rotation().is_none());
+    }
+
+    #[test]
+    fn test_cancelled_rotation_clears_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &2);
+        client.approve_rotate_signers(&signers.get(1).unwrap());
+
+        client.cancel_rotate_signers(&signers.get(2).unwrap());
+
+        // Cancelling clears the proposal entirely.
+        assert!(client.pending_rotation().is_none());
+
+        // The original signer set / threshold are untouched by the aborted rotation.
+        assert_eq!(client.signers(), signers);
+        assert_eq!(client.threshold(), 3);
+
+        // A stale approve/execute/cancel against the cleared proposal fails cleanly.
+        let res = client.try_approve_rotate_signers(&signers.get(3).unwrap());
+        assert_eq!(res, Err(Ok(SenderError::NoPendingRotation)));
+        let res = client.try_execute_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(SenderError::NoPendingRotation)));
+        let res = client.try_cancel_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(SenderError::NoPendingRotation)));
+
+        // A fresh proposal can be made immediately — no leftover state blocks it.
+        let other_signers =
+            soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &other_signers, &2);
+        assert!(client.pending_rotation().is_some());
+    }
+
+    #[test]
+    fn test_non_signer_cannot_propose_or_approve() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+        let outsider = Address::generate(&env);
+
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+        let res = client.try_propose_rotate_signers(&outsider, &new_signers, &2);
+        assert_eq!(res, Err(Ok(SenderError::NotSigner)));
+
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &2);
+        let res = client.try_approve_rotate_signers(&outsider);
+        assert_eq!(res, Err(Ok(SenderError::NotSigner)));
     }
 }

--- a/stellar/stealth-sender/src/multisig.rs
+++ b/stellar/stealth-sender/src/multisig.rs
@@ -1,0 +1,179 @@
+//! On-chain multi-sig quorum + timelock signer-rotation flow.
+//!
+//! Governance signers propose a new signer set and threshold. The proposal
+//! must collect approvals from a quorum of the *current* signers and wait
+//! out a timelock before it can be executed, mirroring the upgrade timelock
+//! described in GOVERNANCE.md / MULTISIG.md. This module only manages the
+//! governance signer set + threshold; it is deliberately independent of
+//! `DataKey::Announcer` / send logic so a bad rotation can never brick sends.
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+
+use crate::{DataKey, SenderError};
+
+/// 7 days, matching the GOVERNANCE.md upgrade timelock.
+pub const ROTATION_TIMELOCK_SECS: u64 = 7 * 24 * 60 * 60;
+
+/// A pending signer-rotation proposal.
+#[contracttype]
+#[derive(Clone)]
+pub struct RotationProposal {
+    pub new_signers: Vec<Address>,
+    pub new_threshold: u32,
+    pub executable_at: u64,
+    pub approvals: Vec<Address>,
+}
+
+/// One-time setup of the governance signer set. Must be called before any
+/// rotation function.
+pub fn init(env: &Env, signers: Vec<Address>, threshold: u32) -> Result<(), SenderError> {
+    if env.storage().instance().has(&DataKey::MultisigSigners) {
+        return Err(SenderError::MultisigAlreadyInitialized);
+    }
+    validate_threshold(&signers, threshold)?;
+
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigSigners, &signers);
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigThreshold, &threshold);
+    Ok(())
+}
+
+pub fn signers(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::MultisigSigners)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn threshold(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MultisigThreshold)
+        .unwrap_or(0)
+}
+
+pub fn pending_rotation(env: &Env) -> Option<RotationProposal> {
+    env.storage().instance().get(&DataKey::PendingRotation)
+}
+
+fn require_signer(env: &Env, caller: &Address) -> Result<(), SenderError> {
+    caller.require_auth();
+    if !signers(env).contains(caller) {
+        return Err(SenderError::NotSigner);
+    }
+    Ok(())
+}
+
+/// Rejects a threshold of zero or a threshold greater than the proposed
+/// signer count — a quorum that could never be reached.
+fn validate_threshold(signers: &Vec<Address>, threshold: u32) -> Result<(), SenderError> {
+    if threshold == 0 || threshold > signers.len() {
+        return Err(SenderError::InvalidThreshold);
+    }
+    Ok(())
+}
+
+/// Propose a new signer set + threshold. The caller's approval is recorded
+/// automatically. Only one rotation may be pending at a time.
+pub fn propose_rotate_signers(
+    env: &Env,
+    caller: Address,
+    new_signers: Vec<Address>,
+    new_threshold: u32,
+) -> Result<(), SenderError> {
+    if !env.storage().instance().has(&DataKey::MultisigSigners) {
+        return Err(SenderError::MultisigNotInitialized);
+    }
+    require_signer(env, &caller)?;
+
+    if env.storage().instance().has(&DataKey::PendingRotation) {
+        return Err(SenderError::RotationAlreadyPending);
+    }
+
+    validate_threshold(&new_signers, new_threshold)?;
+
+    let mut approvals = Vec::new(env);
+    approvals.push_back(caller);
+
+    let proposal = RotationProposal {
+        new_signers,
+        new_threshold,
+        executable_at: env.ledger().timestamp() + ROTATION_TIMELOCK_SECS,
+        approvals,
+    };
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingRotation, &proposal);
+    Ok(())
+}
+
+/// Add the caller's approval to the pending rotation proposal.
+pub fn approve_rotate_signers(env: &Env, caller: Address) -> Result<(), SenderError> {
+    require_signer(env, &caller)?;
+
+    let mut proposal: RotationProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingRotation)
+        .ok_or(SenderError::NoPendingRotation)?;
+
+    if proposal.approvals.contains(&caller) {
+        return Err(SenderError::AlreadyApprovedRotation);
+    }
+    proposal.approvals.push_back(caller);
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingRotation, &proposal);
+    Ok(())
+}
+
+/// Execute the pending rotation once quorum (measured against the *current*
+/// threshold) has been reached and the timelock has elapsed. Clears the
+/// pending proposal and emits `SignersRotated`.
+pub fn execute_rotate_signers(env: &Env, caller: Address) -> Result<(), SenderError> {
+    require_signer(env, &caller)?;
+
+    let proposal: RotationProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingRotation)
+        .ok_or(SenderError::NoPendingRotation)?;
+
+    let old_threshold = threshold(env);
+    if (proposal.approvals.len()) < old_threshold {
+        return Err(SenderError::QuorumNotMet);
+    }
+    if env.ledger().timestamp() < proposal.executable_at {
+        return Err(SenderError::TimelockNotElapsed);
+    }
+
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigSigners, &proposal.new_signers);
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigThreshold, &proposal.new_threshold);
+    env.storage().instance().remove(&DataKey::PendingRotation);
+
+    env.events().publish(
+        (Symbol::new(env, "SignersRotated"),),
+        (proposal.new_signers, old_threshold, proposal.new_threshold),
+    );
+
+    Ok(())
+}
+
+/// Cancel the pending rotation, fully clearing its storage so a future
+/// proposal starts from a clean slate.
+pub fn cancel_rotate_signers(env: &Env, caller: Address) -> Result<(), SenderError> {
+    require_signer(env, &caller)?;
+
+    if !env.storage().instance().has(&DataKey::PendingRotation) {
+        return Err(SenderError::NoPendingRotation);
+    }
+    env.storage().instance().remove(&DataKey::PendingRotation);
+    Ok(())
+}

--- a/stellar/wraith-names/src/lib.rs
+++ b/stellar/wraith-names/src/lib.rs
@@ -8,6 +8,9 @@ use soroban_sdk::{
     String, Vec,
 };
 
+mod multisig;
+pub use multisig::RotationProposal;
+
 pub const WRAITH_NAMES_DOMAIN: &[u8] = b"wraith-names:v1";
 
 const DELAY_WINDOW: u32 = 100_000;
@@ -26,6 +29,12 @@ pub enum DataKey {
     Guardians(BytesN<32>),
     /// Pending recovery proposal for a name.
     Recovery(BytesN<32>),
+    /// Protocol-level governance multisig signer set.
+    MultisigSigners,
+    /// Protocol-level governance multisig quorum threshold.
+    MultisigThreshold,
+    /// Pending protocol-level signer-rotation proposal, if any.
+    PendingRotation,
 }
 
 /// A registered name entry.
@@ -84,6 +93,22 @@ pub enum NamesError {
     InvalidThreshold = 18,
     InvalidExtendLedger = 19,
     ParentNotFound = 20,
+    /// The protocol-level governance multisig has not been initialised.
+    MultisigNotInitialized = 21,
+    /// The protocol-level governance multisig has already been initialised.
+    MultisigAlreadyInitialized = 22,
+    /// The caller is not a current protocol-level governance signer.
+    NotSigner = 23,
+    /// A signer-rotation proposal is already pending.
+    RotationAlreadyPending = 24,
+    /// No signer-rotation proposal is pending.
+    NoPendingRotation = 25,
+    /// The caller has already approved the pending rotation.
+    AlreadyApprovedRotation = 26,
+    /// The pending rotation has not collected enough approvals yet.
+    QuorumNotMet = 27,
+    /// The rotation timelock has not elapsed yet.
+    TimelockNotElapsed = 28,
 }
 
 const TTL_THRESHOLD: u32 = 17280; // ~1 day
@@ -548,6 +573,59 @@ impl WraithNamesContract {
         }
         Ok(())
     }
+
+    /// One-time setup of the protocol-level governance signer set used to
+    /// authorise signer rotations.
+    pub fn init_multisig(
+        env: Env,
+        signers: Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), NamesError> {
+        multisig::init(&env, signers, threshold)
+    }
+
+    /// Current protocol-level governance signer set.
+    pub fn signers(env: Env) -> Vec<Address> {
+        multisig::signers(&env)
+    }
+
+    /// Current protocol-level governance quorum threshold.
+    pub fn threshold(env: Env) -> u32 {
+        multisig::threshold(&env)
+    }
+
+    /// The pending signer-rotation proposal, if any.
+    pub fn pending_rotation(env: Env) -> Option<RotationProposal> {
+        multisig::pending_rotation(&env)
+    }
+
+    /// Propose a new signer set + threshold behind the rotation timelock.
+    /// `caller` must be a current signer; the proposal is auto-approved by
+    /// `caller`. Rejects thresholds that could never reach quorum.
+    pub fn propose_rotate_signers(
+        env: Env,
+        caller: Address,
+        new_signers: Vec<Address>,
+        new_threshold: u32,
+    ) -> Result<(), NamesError> {
+        multisig::propose_rotate_signers(&env, caller, new_signers, new_threshold)
+    }
+
+    /// Approve the pending signer-rotation proposal.
+    pub fn approve_rotate_signers(env: Env, caller: Address) -> Result<(), NamesError> {
+        multisig::approve_rotate_signers(&env, caller)
+    }
+
+    /// Execute the pending rotation once quorum is met and the timelock has
+    /// elapsed. Emits `SignersRotated`.
+    pub fn execute_rotate_signers(env: Env, caller: Address) -> Result<(), NamesError> {
+        multisig::execute_rotate_signers(&env, caller)
+    }
+
+    /// Cancel the pending rotation, clearing all of its state.
+    pub fn cancel_rotate_signers(env: Env, caller: Address) -> Result<(), NamesError> {
+        multisig::cancel_rotate_signers(&env, caller)
+    }
 }
 
 #[cfg(test)]
@@ -962,5 +1040,146 @@ mod test {
         // Dotted names are rejected (subdomain nesting is not yet supported).
         let result = client.try_register(&owner, &String::from_str(&env, "a.b.alice"), &meta);
         assert_eq!(result, Err(Ok(NamesError::InvalidNameCharacter)));
+    }
+
+    fn setup_multisig(env: &Env) -> (WraithNamesContractClient, Vec<Address>) {
+        let contract_id = env.register(WraithNamesContract, ());
+        let client = WraithNamesContractClient::new(env, &contract_id);
+
+        let signers = soroban_sdk::vec![
+            env,
+            Address::generate(env),
+            Address::generate(env),
+            Address::generate(env),
+            Address::generate(env),
+            Address::generate(env),
+        ];
+        client.init_multisig(&signers, &3);
+
+        (client, signers)
+    }
+
+    #[test]
+    fn test_init_multisig_rejects_invalid_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(WraithNamesContract, ());
+        let client = WraithNamesContractClient::new(&env, &contract_id);
+
+        let signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+
+        let res = client.try_init_multisig(&signers, &0);
+        assert_eq!(res, Err(Ok(NamesError::InvalidThreshold)));
+
+        let res = client.try_init_multisig(&signers, &3);
+        assert_eq!(res, Err(Ok(NamesError::InvalidThreshold)));
+    }
+
+    #[test]
+    fn test_propose_rotate_signers_rejects_invalid_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+
+        let res = client.try_propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &0);
+        assert_eq!(res, Err(Ok(NamesError::InvalidThreshold)));
+
+        let res = client.try_propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &3);
+        assert_eq!(res, Err(Ok(NamesError::InvalidThreshold)));
+
+        assert!(client.pending_rotation().is_none());
+    }
+
+    #[test]
+    fn test_rotate_signers_requires_quorum_and_timelock() {
+        use soroban_sdk::testutils::Ledger;
+
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &2);
+
+        // Only one rotation may be pending at a time.
+        let res = client.try_propose_rotate_signers(&signers.get(1).unwrap(), &new_signers, &2);
+        assert_eq!(res, Err(Ok(NamesError::RotationAlreadyPending)));
+
+        // Only 1 of 3 required approvals so far (the proposer's).
+        let res = client.try_execute_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(NamesError::QuorumNotMet)));
+
+        client.approve_rotate_signers(&signers.get(1).unwrap());
+        client.approve_rotate_signers(&signers.get(2).unwrap());
+
+        // Quorum met, but the timelock has not elapsed yet.
+        let res = client.try_execute_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(NamesError::TimelockNotElapsed)));
+
+        env.ledger().with_mut(|li| {
+            li.timestamp += multisig::ROTATION_TIMELOCK_SECS;
+        });
+
+        client.execute_rotate_signers(&signers.get(0).unwrap());
+
+        assert_eq!(client.signers(), new_signers);
+        assert_eq!(client.threshold(), 2);
+        assert!(client.pending_rotation().is_none());
+    }
+
+    #[test]
+    fn test_cancelled_rotation_clears_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &2);
+        client.approve_rotate_signers(&signers.get(1).unwrap());
+
+        client.cancel_rotate_signers(&signers.get(2).unwrap());
+
+        // Cancelling clears the proposal entirely.
+        assert!(client.pending_rotation().is_none());
+
+        // The original signer set / threshold are untouched by the aborted rotation.
+        assert_eq!(client.signers(), signers);
+        assert_eq!(client.threshold(), 3);
+
+        // A stale approve/execute/cancel against the cleared proposal fails cleanly.
+        let res = client.try_approve_rotate_signers(&signers.get(3).unwrap());
+        assert_eq!(res, Err(Ok(NamesError::NoPendingRotation)));
+        let res = client.try_execute_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(NamesError::NoPendingRotation)));
+        let res = client.try_cancel_rotate_signers(&signers.get(0).unwrap());
+        assert_eq!(res, Err(Ok(NamesError::NoPendingRotation)));
+
+        // A fresh proposal can be made immediately — no leftover state blocks it.
+        let other_signers =
+            soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &other_signers, &2);
+        assert!(client.pending_rotation().is_some());
+    }
+
+    #[test]
+    fn test_non_signer_cannot_propose_or_approve() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, signers) = setup_multisig(&env);
+        let outsider = Address::generate(&env);
+
+        let new_signers = soroban_sdk::vec![&env, Address::generate(&env), Address::generate(&env)];
+        let res = client.try_propose_rotate_signers(&outsider, &new_signers, &2);
+        assert_eq!(res, Err(Ok(NamesError::NotSigner)));
+
+        client.propose_rotate_signers(&signers.get(0).unwrap(), &new_signers, &2);
+        let res = client.try_approve_rotate_signers(&outsider);
+        assert_eq!(res, Err(Ok(NamesError::NotSigner)));
     }
 }

--- a/stellar/wraith-names/src/multisig.rs
+++ b/stellar/wraith-names/src/multisig.rs
@@ -1,0 +1,181 @@
+//! On-chain multi-sig quorum + timelock signer-rotation flow.
+//!
+//! Governance signers propose a new signer set and threshold. The proposal
+//! must collect approvals from a quorum of the *current* signers and wait
+//! out a timelock before it can be executed, mirroring the upgrade timelock
+//! described in GOVERNANCE.md / MULTISIG.md. This is the protocol-level
+//! governance signer set for `wraith-names` itself — distinct from the
+//! per-name `GuardianConfig` recovery guardians defined elsewhere in this
+//! crate, which govern individual name ownership rather than the contract.
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+
+use crate::{DataKey, NamesError};
+
+/// 7 days, matching the GOVERNANCE.md upgrade timelock.
+pub const ROTATION_TIMELOCK_SECS: u64 = 7 * 24 * 60 * 60;
+
+/// A pending signer-rotation proposal.
+#[contracttype]
+#[derive(Clone)]
+pub struct RotationProposal {
+    pub new_signers: Vec<Address>,
+    pub new_threshold: u32,
+    pub executable_at: u64,
+    pub approvals: Vec<Address>,
+}
+
+/// One-time setup of the governance signer set used to authorise signer
+/// rotations.
+pub fn init(env: &Env, signers: Vec<Address>, threshold: u32) -> Result<(), NamesError> {
+    if env.storage().instance().has(&DataKey::MultisigSigners) {
+        return Err(NamesError::MultisigAlreadyInitialized);
+    }
+    validate_threshold(&signers, threshold)?;
+
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigSigners, &signers);
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigThreshold, &threshold);
+    Ok(())
+}
+
+pub fn signers(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::MultisigSigners)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn threshold(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MultisigThreshold)
+        .unwrap_or(0)
+}
+
+pub fn pending_rotation(env: &Env) -> Option<RotationProposal> {
+    env.storage().instance().get(&DataKey::PendingRotation)
+}
+
+fn require_signer(env: &Env, caller: &Address) -> Result<(), NamesError> {
+    caller.require_auth();
+    if !signers(env).contains(caller) {
+        return Err(NamesError::NotSigner);
+    }
+    Ok(())
+}
+
+/// Rejects a threshold of zero or a threshold greater than the proposed
+/// signer count — a quorum that could never be reached.
+fn validate_threshold(signers: &Vec<Address>, threshold: u32) -> Result<(), NamesError> {
+    if threshold == 0 || threshold > signers.len() {
+        return Err(NamesError::InvalidThreshold);
+    }
+    Ok(())
+}
+
+/// Propose a new signer set + threshold behind the rotation timelock. The
+/// caller's approval is recorded automatically. Only one rotation may be
+/// pending at a time.
+pub fn propose_rotate_signers(
+    env: &Env,
+    caller: Address,
+    new_signers: Vec<Address>,
+    new_threshold: u32,
+) -> Result<(), NamesError> {
+    if !env.storage().instance().has(&DataKey::MultisigSigners) {
+        return Err(NamesError::MultisigNotInitialized);
+    }
+    require_signer(env, &caller)?;
+
+    if env.storage().instance().has(&DataKey::PendingRotation) {
+        return Err(NamesError::RotationAlreadyPending);
+    }
+
+    validate_threshold(&new_signers, new_threshold)?;
+
+    let mut approvals = Vec::new(env);
+    approvals.push_back(caller);
+
+    let proposal = RotationProposal {
+        new_signers,
+        new_threshold,
+        executable_at: env.ledger().timestamp() + ROTATION_TIMELOCK_SECS,
+        approvals,
+    };
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingRotation, &proposal);
+    Ok(())
+}
+
+/// Add the caller's approval to the pending rotation proposal.
+pub fn approve_rotate_signers(env: &Env, caller: Address) -> Result<(), NamesError> {
+    require_signer(env, &caller)?;
+
+    let mut proposal: RotationProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingRotation)
+        .ok_or(NamesError::NoPendingRotation)?;
+
+    if proposal.approvals.contains(&caller) {
+        return Err(NamesError::AlreadyApprovedRotation);
+    }
+    proposal.approvals.push_back(caller);
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingRotation, &proposal);
+    Ok(())
+}
+
+/// Execute the pending rotation once quorum (measured against the *current*
+/// threshold) has been reached and the timelock has elapsed. Clears the
+/// pending proposal and emits `SignersRotated`.
+pub fn execute_rotate_signers(env: &Env, caller: Address) -> Result<(), NamesError> {
+    require_signer(env, &caller)?;
+
+    let proposal: RotationProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingRotation)
+        .ok_or(NamesError::NoPendingRotation)?;
+
+    let old_threshold = threshold(env);
+    if (proposal.approvals.len()) < old_threshold {
+        return Err(NamesError::QuorumNotMet);
+    }
+    if env.ledger().timestamp() < proposal.executable_at {
+        return Err(NamesError::TimelockNotElapsed);
+    }
+
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigSigners, &proposal.new_signers);
+    env.storage()
+        .instance()
+        .set(&DataKey::MultisigThreshold, &proposal.new_threshold);
+    env.storage().instance().remove(&DataKey::PendingRotation);
+
+    env.events().publish(
+        (Symbol::new(env, "SignersRotated"),),
+        (proposal.new_signers, old_threshold, proposal.new_threshold),
+    );
+
+    Ok(())
+}
+
+/// Cancel the pending rotation, fully clearing its storage so a future
+/// proposal starts from a clean slate.
+pub fn cancel_rotate_signers(env: &Env, caller: Address) -> Result<(), NamesError> {
+    require_signer(env, &caller)?;
+
+    if !env.storage().instance().has(&DataKey::PendingRotation) {
+        return Err(NamesError::NoPendingRotation);
+    }
+    env.storage().instance().remove(&DataKey::PendingRotation);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #104. Adds an on-chain rotate_signers flow - gated by quorum-of-current-signers plus a 7-day timelock - to the two contracts GOVERNANCE.md designates Timelock + Multisig Upgradable: stealth-sender and wraith-names.

## Why both contracts

The issue's suggested path (contracts/*/src/multisig.rs) is a glob; this repo has no single admin-gated contract to attach it to - today's admin is a plain Stellar account address, multisig'd off-chain (see MULTISIG.md), with zero on-chain visibility into signers/threshold from any contract. GOVERNANCE.md designates both stealth-sender and wraith-names as Timelock + Multisig Upgradable with the same 3-of-5 / 7-day model, so both got a symmetric src/multisig.rs module rather than picking one arbitrarily.

## Design

Each contract tracks its own governance signer set independently (DataKey::MultisigSigners / MultisigThreshold / PendingRotation) - this is a second, independent layer from the account-level Stellar multisig: the account multisig controls who can submit transactions at all; this controls quorum + timelock for signer rotation specifically, enforced by the contract regardless of which account submitted the call.

Flow: init_multisig (one-shot bootstrap) -> propose_rotate_signers (any current signer; auto-approves; only one rotation pending at a time) -> approve_rotate_signers (remaining signers, asynchronously - matches the existing off-chain MULTISIG.md 'collect M signatures over time' UX rather than requiring one atomic co-signed transaction) -> execute_rotate_signers (once approvals >= current threshold AND 7 days have elapsed since proposal; emits SignersRotated(new_signers, old_threshold, new_threshold)) -> cancel_rotate_signers (any current signer, any time before execution; fully clears proposal state so a fresh rotation can be proposed immediately).

InvalidThreshold is a dedicated error rejecting threshold 0 or threshold > new_signers.len(), at both init_multisig and propose_rotate_signers.

## Acceptance criteria

- [x] Rotation requires quorum + timelock - test_rotate_signers_requires_quorum_and_timelock (both contracts): asserts QuorumNotMet with insufficient approvals, TimelockNotElapsed after quorum but before the delay, success after both.
- [x] Invalid thresholds rejected with dedicated error - test_init_multisig_rejects_invalid_threshold, test_propose_rotate_signers_rejects_invalid_threshold.
- [x] Test covers cancelled-mid-rotation state cleanup - test_cancelled_rotation_clears_state: cancel mid-approval, confirms proposal/approvals are fully cleared, original signers/threshold untouched, a stale approve/execute/cancel against the cleared proposal fails with NoPendingRotation, and a fresh proposal can be made immediately.
- [x] Bonus: test_non_signer_cannot_propose_or_approve.
- [x] MULTISIG.md updated with the on-chain rotation runbook (CLI examples for every step plus a state-inspection section).
- [ ] MULTISIG.md runbook rehearsed on futurenet - not done. This requires a live futurenet deployment and a maintainer with deploy access, which I do not have. Called out explicitly in MULTISIG.md's new 'Futurenet rehearsal' section as not yet rehearsed, with the exact walkthrough steps a maintainer should follow (propose -> approve x2 -> advance past 7-day timelock -> execute, and separately propose -> approve -> cancel -> propose again) before relying on this runbook for a real mainnet rotation.

## Test location note

Tests are inline in each contract's existing #[cfg(test)] mod test in src/lib.rs, matching how every existing test in both stealth-sender and wraith-names is already organized (there is no per-contract tests/ directory convention in use, and the repo's shared integration-tests crate is currently non-functional - its src is a stray file containing a misnamed Cargo.toml, no real harness - so a new file there wouldn't compile without unrelated scaffolding repair).

## Test plan

- [ ] cd stellar && cargo test -p stealth-sender -p wraith-names (I could not run this locally - this sandbox has no MSVC linker installed and the available MinGW toolchain fails to link due to a space in its own install path, unrelated to this repo. Please run in CI / locally before merge.)
- [x] Manual review of every call against soroban-sdk 22 APIs already used elsewhere in both files (Vec::contains, env.ledger().timestamp(), env.storage().instance(), Symbol::new).
